### PR TITLE
add per-site alwaysAllowWorldSensing option to popup, and both a global-allow and a reset switch to settings

### DIFF
--- a/XRViewer/Constants/Constants.h
+++ b/XRViewer/Constants/Constants.h
@@ -39,4 +39,8 @@ FOUNDATION_EXPORT NSString *const backgroundOrPausedDateKey;
 /// anchors on the next session run
 FOUNDATION_EXPORT double const pauseTimeInSecondsToRemoveAnchors;
 
+/// The NSUserDefaults key for the boolean that tells us whether
+/// the allow world sensing dialog should be shown
+FOUNDATION_EXPORT NSString *const alwaysAllowWorldSensingKey;
+
 #endif /* Constants_h */

--- a/XRViewer/Constants/Constants.h
+++ b/XRViewer/Constants/Constants.h
@@ -40,7 +40,10 @@ FOUNDATION_EXPORT NSString *const backgroundOrPausedDateKey;
 FOUNDATION_EXPORT double const pauseTimeInSecondsToRemoveAnchors;
 
 /// The NSUserDefaults key for the boolean that tells us whether
-/// the allow world sensing dialog should be shown
+/// the allow world sensing dialog should be shown (globally)
 FOUNDATION_EXPORT NSString *const alwaysAllowWorldSensingKey;
+/// The NSUserDefaults key for the boolean that tells us whether
+/// the allow world sensing dialog should be shown for sites
+FOUNDATION_EXPORT NSString *const allowedWorldSensingSitesKey;
 
 #endif /* Constants_h */

--- a/XRViewer/Constants/Constants.m
+++ b/XRViewer/Constants/Constants.m
@@ -17,3 +17,5 @@ NSString *const backgroundOrPausedDateKey = @"backgroundOrPausedDateKey";
 int const sessionInBackgroundDefaultTimeInSeconds = 60;
 float const distantAnchorsDefaultDistanceInMeters = 3.0;
 double const pauseTimeInSecondsToRemoveAnchors = 10.0;
+
+NSString *const alwaysAllowWorldSensingKey = @"alwaysAllowWorldSensingKey";

--- a/XRViewer/Constants/Constants.m
+++ b/XRViewer/Constants/Constants.m
@@ -19,3 +19,4 @@ float const distantAnchorsDefaultDistanceInMeters = 3.0;
 double const pauseTimeInSecondsToRemoveAnchors = 10.0;
 
 NSString *const alwaysAllowWorldSensingKey = @"alwaysAllowWorldSensingKey";
+NSString *const allowedWorldSensingSitesKey = @"allowedWorldSensingSitesKey";

--- a/XRViewer/MessageController/MessageController.h
+++ b/XRViewer/MessageController/MessageController.h
@@ -49,5 +49,5 @@ typedef NS_ENUM(NSInteger, ResetTrackigOption) {
 
 - (void)showPermissionsPopup;
 
-- (void)showMessageAboutAccessingWorldSensingData:(void (^)(BOOL))granted;
+- (void)showMessageAboutAccessingWorldSensingData:(void (^)(BOOL))granted url:(NSURL*)url;
 @end

--- a/XRViewer/MessageController/MessageController.m
+++ b/XRViewer/MessageController/MessageController.m
@@ -2,6 +2,8 @@
 #import "XRViewer-Swift.h"
 #import <PopupDialog/PopupDialog-Swift.h>
 
+#include "Constants.h"
+
 #warning LOCALIZATION
 
 @interface MessageController ()
@@ -336,6 +338,11 @@
 }
 
 - (void)showMessageAboutAccessingWorldSensingData:(void (^)(BOOL))granted {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:alwaysAllowWorldSensingKey]) {
+        granted(true);
+        return;
+    }
+    
     PopupDialog *popup = [[PopupDialog alloc] initWithTitle:@"Access to World Sensing"
                                                     message:@"This webpage wants to use your camera to look for faces and things in the real world. (For details, see our Privacy Notice in Settings.) Allow?"
                                                       image:nil
@@ -346,6 +353,11 @@
                                               hideStatusBar:TRUE
                                                  completion:^{}
     ];
+    
+    DestructiveButton *always = [[DestructiveButton alloc] initWithTitle:@"ALWAYS" height:40 dismissOnTap:YES action:^{
+        [[NSUserDefaults standardUserDefaults] setBool:TRUE forKey:alwaysAllowWorldSensingKey];
+        granted(true);
+    }];
 
     DestructiveButton *ok = [[DestructiveButton alloc] initWithTitle:@"YES" height:40 dismissOnTap:YES action:^{
         granted(true);
@@ -356,7 +368,7 @@
         granted(false);
     }];
 
-    [popup addButtons: @[cancel, ok]];
+    [popup addButtons: @[cancel, ok, always]];
 
     [[self viewController] presentViewController:popup animated:YES completion:nil];
 }

--- a/XRViewer/SettingsController/SettingsViewController.swift
+++ b/XRViewer/SettingsController/SettingsViewController.swift
@@ -60,7 +60,7 @@ extension SettingsViewController: UITableViewDataSource {
         if section == 0 {
             return 1
         } else if section == 1 {
-            return 5
+            return 6
         } else {
             return 1
         }
@@ -115,6 +115,13 @@ extension SettingsViewController: UITableViewDataSource {
                 switchInputCell.switchControl.addTarget(self, action: #selector(switchValueChanged(switchControl:)), for: .valueChanged)
                 switchInputCell.switchControl.tag = 4
                 cell = switchInputCell
+            case 5:
+                let switchInputCell = tableView.dequeueReusableCell(withIdentifier: "SwitchInputTableViewCell", for: indexPath) as! SwitchInputTableViewCell
+                switchInputCell.labelTitle?.text = "Reset Allowed World Sensing"
+                switchInputCell.switchControl.isOn = UserDefaults.standard.object(forKey: allowedWorldSensingSitesKey) == nil && !UserDefaults.standard.bool(forKey: alwaysAllowWorldSensingKey);
+                switchInputCell.switchControl.addTarget(self, action: #selector(switchValueChanged(switchControl:)), for: .valueChanged)
+                switchInputCell.switchControl.tag = 5
+                cell = switchInputCell
             default:
                 fatalError("Cell not registered for indexPath: \(indexPath)")
             }
@@ -139,6 +146,12 @@ extension SettingsViewController: UITableViewDataSource {
             UserDefaults.standard.set(switchControl.isOn, forKey: useAnalyticsKey)
         } else if switchControl.tag == 4 {
             UserDefaults.standard.set(switchControl.isOn, forKey: alwaysAllowWorldSensingKey)
+        } else if switchControl.tag == 5 {
+            // Forget any sites remembered
+            UserDefaults.standard.removeObject(forKey: allowedWorldSensingSitesKey)
+            // Assume that if they are resetting, should NOT be always-on.
+            // FIXME: This doesn't update the always-on switch control?
+            UserDefaults.standard.set(false, forKey: alwaysAllowWorldSensingKey)
         }
     }
 }

--- a/XRViewer/SettingsController/SettingsViewController.swift
+++ b/XRViewer/SettingsController/SettingsViewController.swift
@@ -60,7 +60,7 @@ extension SettingsViewController: UITableViewDataSource {
         if section == 0 {
             return 1
         } else if section == 1 {
-            return 4
+            return 5
         } else {
             return 1
         }
@@ -87,8 +87,10 @@ extension SettingsViewController: UITableViewDataSource {
                 cell = textInputCell
             case 1:
                 let switchInputCell = tableView.dequeueReusableCell(withIdentifier: "SwitchInputTableViewCell", for: indexPath) as! SwitchInputTableViewCell
+                switchInputCell.labelTitle?.text = "Send Tech and Interaction Data"
                 switchInputCell.switchControl.isOn = UserDefaults.standard.bool(forKey: useAnalyticsKey)
                 switchInputCell.switchControl.addTarget(self, action: #selector(switchValueChanged(switchControl:)), for: .valueChanged)
+                switchInputCell.switchControl.tag = 1
                 cell = switchInputCell
             case 2:
                 let textInputCell = tableView.dequeueReusableCell(withIdentifier: "TextInputTableViewCell", for: indexPath) as! TextInputTableViewCell
@@ -106,6 +108,13 @@ extension SettingsViewController: UITableViewDataSource {
                 textInputCell.textField.delegate = self
                 textInputCell.textField.tag = 3
                 cell = textInputCell
+            case 4:
+                let switchInputCell = tableView.dequeueReusableCell(withIdentifier: "SwitchInputTableViewCell", for: indexPath) as! SwitchInputTableViewCell
+                switchInputCell.labelTitle?.text = "Always Allow World Sensing"
+                switchInputCell.switchControl.isOn = UserDefaults.standard.bool(forKey: alwaysAllowWorldSensingKey)
+                switchInputCell.switchControl.addTarget(self, action: #selector(switchValueChanged(switchControl:)), for: .valueChanged)
+                switchInputCell.switchControl.tag = 4
+                cell = switchInputCell
             default:
                 fatalError("Cell not registered for indexPath: \(indexPath)")
             }
@@ -126,7 +135,11 @@ extension SettingsViewController: UITableViewDataSource {
     }
     
     @objc func switchValueChanged(switchControl: UISwitch) {
-        UserDefaults.standard.set(switchControl.isOn, forKey: useAnalyticsKey)
+        if switchControl.tag == 1 {
+            UserDefaults.standard.set(switchControl.isOn, forKey: useAnalyticsKey)
+        } else if switchControl.tag == 4 {
+            UserDefaults.standard.set(switchControl.isOn, forKey: alwaysAllowWorldSensingKey)
+        }
     }
 }
 

--- a/XRViewer/SettingsController/SwitchInputTableViewCell.swift
+++ b/XRViewer/SettingsController/SwitchInputTableViewCell.swift
@@ -11,6 +11,7 @@ import UIKit
 class SwitchInputTableViewCell: UITableViewCell {
 
     @IBOutlet weak var switchControl: UISwitch!
+    @IBOutlet weak var labelTitle: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/XRViewer/SettingsController/SwitchInputTableViewCell.xib
+++ b/XRViewer/SettingsController/SwitchInputTableViewCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14269.12" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14252.5"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,14 +19,14 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Send Tech and Interaction Data" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="9A2-nf-OV5">
-                        <rect key="frame" x="8" y="12" width="247" height="21"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Send Tech and Interaction Data" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="9A2-nf-OV5" userLabel="Label Title">
+                        <rect key="frame" x="8" y="11.5" width="247" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LEc-Qq-gFS">
-                        <rect key="frame" x="263" y="6" width="51" height="31"/>
+                        <rect key="frame" x="263" y="6.5" width="51" height="31"/>
                     </switch>
                 </subviews>
                 <constraints>
@@ -38,6 +39,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="labelTitle" destination="9A2-nf-OV5" id="5q5-yo-gCp"/>
                 <outlet property="switchControl" destination="LEc-Qq-gFS" id="ZOM-FI-YwP"/>
             </connections>
         </tableViewCell>

--- a/XRViewer/ViewController/ViewController.m
+++ b/XRViewer/ViewController/ViewController.m
@@ -1118,7 +1118,7 @@ typedef void (^UICompletion)(void);
         [[self messageController] showMessageAboutAccessingWorldSensingData:^(BOOL granted){
             [[blockSelf webController] userGrantedSendingWorldSensingData:granted];
             [[blockSelf arkController] setSendingWorldSensingDataAuthorizationStatus: granted ? SendWorldSensingDataAuthorizationStateAuthorized: SendWorldSensingDataAuthorizationStateDenied];
-        }];
+        } url:[[[self webController] webView] URL]];
     } else {
         // if neither is requested, we'll actually set it to denied!
         [[blockSelf arkController] setSendingWorldSensingDataAuthorizationStatus: SendWorldSensingDataAuthorizationStateDenied];


### PR DESCRIPTION
To improve upon the UX of prompting the user to allow world sensing every time, this PR adds another option to the popup to always allow from this site (host:port), and adds both a global-allow switch and a reset switch to Settings.  (Note that to avoid complexities, there is not a site-by-site management option.)